### PR TITLE
Updated function to take url change only on button click.

### DIFF
--- a/django_project/frontend/src/pages/Admin/Importer/Form/Extensions/SDMX/DsdComponents/DsdForm.jsx
+++ b/django_project/frontend/src/pages/Admin/Importer/Form/Extensions/SDMX/DsdComponents/DsdForm.jsx
@@ -25,6 +25,8 @@ const DsdForm = ({ urlChanged, setRequest }) => {
 
   const [dsdResult, setDsdResult] = useState(null);
 
+  const [currentUrl, setCurrentUrl] = useState(null);
+
   const [loading, setLoading] = useState({
     agency: false,
     dataflow: false,
@@ -54,9 +56,14 @@ const DsdForm = ({ urlChanged, setRequest }) => {
   // Fetch DSD on dimension change
   useEffect(() => {
     if (!selectedDataflow) return;
-    fetchDsd(selectedDataflow, dimensionSelections, setDsdResult, urlChanged, setError, setLoading);
+    fetchDsd(selectedDataflow, dimensionSelections, setDsdResult, setCurrentUrl, setError, setLoading);
 
   }, [dimensionSelections, selectedDataflow]);
+
+  const handleSubmit = async () => {
+    urlChanged(currentUrl);
+  };
+
 
   // Handle dimension selection change
   const handleDimensionChange = async (dimensionId, selectedOptions) => {
@@ -146,6 +153,7 @@ const DsdForm = ({ urlChanged, setRequest }) => {
           </div>
         </section>
       )}
+      <button onClick={handleSubmit}>Submit</button>
     </div>
   );
 };

--- a/django_project/frontend/src/pages/Admin/Importer/Form/Extensions/SDMX/DsdComponents/fetchFunctions.jsx
+++ b/django_project/frontend/src/pages/Admin/Importer/Form/Extensions/SDMX/DsdComponents/fetchFunctions.jsx
@@ -56,7 +56,7 @@ export const fetchDimensions = async (setLoading, setError, setDimensionOptions,
     }
   };
 
-export const fetchDsd = async (selectedDataflow, dimensionSelections, setDsdResult, urlChanged, setError, setLoading) => {
+export const fetchDsd = async (selectedDataflow, dimensionSelections, setDsdResult, setCurrentUrl, setError, setLoading) => {
     setLoading((prev) => ({ ...prev, dsd: true }));
     try {
       const result = await updateDsd({
@@ -68,7 +68,7 @@ export const fetchDsd = async (selectedDataflow, dimensionSelections, setDsdResu
       if (result.error) throw new Error(result.error);
 
       setDsdResult(result);
-      urlChanged(result.apiUrl.split("?")[0] + "?format=csv");
+      setCurrentUrl(result.apiUrl.split("?")[0] + "?format=csv");
       setError((prev) => ({ ...prev, dsd: null }));
     } catch {
       setError((prev) => ({ ...prev, dsd: "Error fetching DSD." }));


### PR DESCRIPTION
Changed function of changing url to only be triggered upon button click
- Small change for button triggered pull for data
- The other data is still pulled automatically, like for the dimensions, agency, and dataflow, but those must be, as they update with the user's selections